### PR TITLE
Remove HTML tags from "connected as" message.

### DIFF
--- a/l10n/de_DE.inc
+++ b/l10n/de_DE.inc
@@ -45,7 +45,7 @@ $labels['cannot_link'] = "Das hochladen der Datei war erfolgreich, es konnte abe
 $labels['cloud_attachments'] = "Cloud Anhänge";
 $labels['cloud_server'] = "Cloud Server";
 $labels['status'] = "Status";
-$labels['connected_as'] = "<b style='color: green'>Verbunden</b> als";
+$labels['connected_as'] = "Verbunden als";
 $labels['disconnect'] = "trennen";
 $labels['connect'] = "verbinden";
 $labels['not_connected'] = "Nicht verbunden";

--- a/l10n/en_US.inc
+++ b/l10n/en_US.inc
@@ -45,7 +45,7 @@ $labels['cannot_link'] = "upload of file succeeded, but we couldn't create a sha
 $labels['cloud_attachments'] = "Cloud Attachments";
 $labels['cloud_server'] = "Cloud Server";
 $labels['status'] = "Status";
-$labels['connected_as'] = "<b style='color: green'>Connected</b> as";
+$labels['connected_as'] = "Connected as";
 $labels['disconnect'] = "disconnect";
 $labels['connect'] = "connect";
 $labels['not_connected'] = "Not connected";


### PR DESCRIPTION
They were shown as tags on the page because they were encoded before being shown (as it's correct string handling).

Showing color is a nice idea but would need to be implemented differently, I'd say.