### PR TITLE
Allow configuration of share password length

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -75,6 +75,11 @@ $config["nextcloud_attachment_password_protected_links"] = false;
 // false => user may change the setting
 $config["nextcloud_attachment_password_protected_links_locked"] = true;
 
+// Generated password length
+// Passwords will be alphanumerical strings with upper and lower case letters and numbers
+// Defaults to 12
+$config["nextcloud_attachment_password_length"] = 12;
+
 // Expire share links after amount of days.
 // Links will expire on the last valid day at 11:59:59pm AoE-Time
 // Setting to "false" or negative value disables link expiry

--- a/hooks.php
+++ b/hooks.php
@@ -490,11 +490,12 @@ trait Hooks
 
         $pass_links = $this->rcmail->config->get(__("password_protected_links"), false);
         $pass_links_lock = $this->rcmail->config->get(__("password_protected_links_locked"), false);
+        $pass_length = $this->rcmail->config->get(__("password_length"), 12);
         $pass_links_user = $prefs[__("user_password_protected_links")] ?? false;
 
         if ($pass_links || (!$pass_links_lock && $pass_links_user)) {
             $share_password = "";
-            while(strlen($share_password) <= 12) {
+            while(strlen($share_password) < $pass_length) {
                 $char = openssl_random_pseudo_bytes(1); //ascii 0-z
                 if (preg_match("/[a-zA-Z0-9]/", $char)) {
                     $share_password .= $char;


### PR DESCRIPTION
In some Nextcloud installations, the default password policy (which also affects share link passwords) is changed.

If password protection for attachment shares is enabled, and the password policy of the Nextcloud installation enforces passwords longer than 12 characters, the following error pop-up is shown:

![image](https://github.com/user-attachments/assets/406cd27b-4a3a-4aeb-b3d9-f46947792cd6)